### PR TITLE
Fix hardcoded color in slides.typ

### DIFF
--- a/slides.typ
+++ b/slides.typ
@@ -72,7 +72,7 @@
     )
 
     let decoration(position, body) = {
-        let border = 1mm + teal
+        let border = 1mm + color
         let strokes = (
             header: ( bottom: border ),
             footer: ( top: border )
@@ -109,7 +109,7 @@
 
     [
         #align(center + horizon,
-            block(fill: teal, inset: 1em, radius: 1em, breakable: false,
+            block(fill: color, inset: 1em, radius: 1em, breakable: false,
                 [
                     #text(2em)[*#title*] \
                     #v(1em)


### PR DESCRIPTION
Hey, thank you so much for creating this! It'll certainly be of invaluable help to many in the community, me included.

Just wanted to submit this small patch, as the `color` parameter is currently not working as intended. This should fix that!

Thanks again!