### PR TITLE
add an option to not reserve space for `only` content

### DIFF
--- a/slides.typ
+++ b/slides.typ
@@ -150,12 +150,12 @@
     })
 }
 
-#let only(visible-slide-number, body) = {
+#let only(reserve: true, visible-slide-number, body) = {
     repetitions.update(rep => calc.max(rep, visible-slide-number))
     locate( loc => {
         if subslide.at(loc).first() == visible-slide-number {
             full-box(body)
-        } else {
+        } else if (reserve) {
             slides-custom-hide(body)
         }
     })


### PR DESCRIPTION
Thanks for your work here!

This PR is related to #8 and adds a parameter to only which let the user the option to reserve (or not) space for the hidden content (default is true which preserve the current usage). I switched in favor to not adding a function and reuse only.