### PR TITLE
Implement title slide as normal variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This is a template for creating slides in [Typst](https://typst.app/).
     date: "March 2023",
 )
 
+#slide(theme-variant: "title slide")
+
 #new-section("My section name")
 
 #slide(title: "A boring static slide")[

--- a/book/src/theme-gallery/bipartite.typ
+++ b/book/src/theme-gallery/bipartite.typ
@@ -8,6 +8,8 @@
     theme: bipartite-theme(),
 )
 
+#slide(theme-variant: "title slide")
+
 #new-section("section name")
 
 #slide(title: "A longer slide title")[

--- a/book/src/theme-gallery/default.typ
+++ b/book/src/theme-gallery/default.typ
@@ -6,6 +6,8 @@
     date: "Date",
 )
 
+#slide(theme-variant: "title slide")
+
 #new-section("section name")
 
 #slide(title: "Slide title")[

--- a/book/src/theme-gallery/index.md
+++ b/book/src/theme-gallery/index.md
@@ -22,6 +22,8 @@ You can specify it explicitly by referring to `slides-default-theme`:
 - `color`: the color to use for decorative elements, default `teal`
 
 ### Variants
+- `"title slide"`: displays presentation title and subtitle between horziontal
+  lines above horizontally positioned authors and the date
 - `"wake up"`: no decoration, colored background, enlarged text
 
 ### Extra keyword arguments
@@ -36,6 +38,8 @@ You can specify it explicitly by referring to `slides-default-theme`:
     title: "Title", short-title: "Short title", subtitle: "Subtitle",
     date: "Date",
 )
+
+#slide(theme-variant: "title slide")
 
 #new-section("section name")
 
@@ -68,6 +72,8 @@ It features a dominant partition of space into a bright and a dark side.
 - *none*
 
 ### Variants
+- `"title slide"`: displays presentation title on a large bright portion above
+  the subtitle, the authors and the date
 - `"east"`: same as default variant, but dark side on the right, text is right
   aligned
 - `"center split"`: bright left and dark right half of equal size, requires two
@@ -87,6 +93,8 @@ It features a dominant partition of space into a bright and a dark side.
     date: "Date",
     theme: bipartite-theme(),
 )
+
+#slide(theme-variant: "title slide")
 
 #new-section("section name")
 

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -23,17 +23,16 @@ that this specific slide will look different.
 
 ## Create your own theme
 On a high level, a theme is nothing more than a piece of code that defines how
-the title slide looks and at least one variant defining how the content slides
-look.
+the slides look.
 
 On one level deeper, a theme is a function that takes a `data` dictionary and
-returns a dictionary with the keys `title-slide` and `variants`.
+returns a dictionary with one key for each _variant_.
 Let us build a very simple one for demonstration purposes:
 ```typ
 #let dumb-theme = data => {
   (
-    title-slide: ...,
-    variants: ...,
+    "variant 1": ...,
+    "variant 2": ...,
   )
 }
 ```
@@ -41,8 +40,8 @@ Note that you can easily introduce parameters to your theme:
 ```typ
 #let dumb-theme(parameter) = data => {
   (
-    title-slide: ...,
-    variants: ...,
+    "variant 1": ...,
+    "variant 2": ...,
   )
 }
 ```
@@ -61,16 +60,6 @@ set in the initial `slides` function, i.e. it has the following structure:
 ```
 Use these information however you please.
 
-For example, you could define the title slide in the following way:
-```typ
-#let dumb-theme = data => {
-  (
-    title-slide: align(center + horizon, data.title),
-    variants: ...,
-  )
-}
-```
-
 On to the actual slides.
 Their appearance is defined by functions that accept some meta data, some
 array of contents (the last argument(s) to `#slide`, essentially) and return
@@ -78,8 +67,9 @@ some richer content, somehow styling that slide:
 ```typ
 (dictionary, array of content) => content
 ```
-You can define an arbitrary amount of such functions as values of the `variants`
-dictionary, but one of them must be stored under the key `"default"`.
+We call these functions the _variants_ of the theme.
+You can define an arbitrary amount of them but one must be stored under the key
+`"default"` in your theme.
 
 The meta data referred to above are a dictionary containing any extra keyword
 arguments that the user has specified in their call to `#slide`.
@@ -124,33 +114,43 @@ To make use of some of the functionality this template offers, you can access
 - the state `section`, telling you what the user has currently set as the
   section name.
 
-Let us define two variants:
+Let us define a few variants variants.
+You should probably add a variant for a title slide to your theme.
+By convention, this variant is called `"title slide"`.
 ```typ
 #let dumb-theme = data => {
   (
-    title-slide: align(center + horizon, data.title),
-    variants: (
-      "default": (slide-info, bodies) => {
-        text(.7em, [#slide-info.title (current section: #section.display())])
-        v(1fr)
-        for body in bodies {
-          body
-          v(1em)
-        }
-        v(1fr)
-        text(.7em, [#h(1fr) #logical-slide.display()])
-      },
-      "australia": (slide-info, bodies) => {
-        if bodies.len() != 1 {
-          panic("australia variant expected exactly one body")
-        }
-        text(.7em, [current section: #section.display()])
-        v(1fr)
-        scale(y: -100%, bodies.first())
-        v(1fr)
-        text(.7em, [#h(1fr) #logical-slide.display()])
-      },
-    ),
+    "title slide": (slide-info, bodies) => align(center + horizon, data.title),
+    "variant 2": ...,
+  )
+}
+```
+As noted above, one of the variants must have the name `"default"`.
+
+```typ
+#let dumb-theme = data => {
+  (
+    "title slide": (slide-info, bodies) => align(center + horizon, data.title),
+    "default": (slide-info, bodies) => {
+      text(.7em, [#slide-info.title (current section: #section.display())])
+      v(1fr)
+      for body in bodies {
+        body
+        v(1em)
+      }
+      v(1fr)
+      text(.7em, [#h(1fr) #logical-slide.display()])
+    },
+    "australia": (slide-info, bodies) => {
+      if bodies.len() != 1 {
+        panic("australia variant expected exactly one body")
+      }
+      text(.7em, [current section: #section.display()])
+      v(1fr)
+      scale(y: -100%, bodies.first())
+      v(1fr)
+      text(.7em, [#h(1fr) #logical-slide.display()])
+    },
   )
 }
 ```
@@ -165,6 +165,10 @@ though.
 Also, the `"default"` variant displays all the content blocks provided to `#slide`
 while the `"australia"` variant errors if more or less than one such block is
 given.
+
+The `"title slide"` variant uses neither the `slide-info` nor the `bodies`.
+That is a usual behaviour, as title slides normally only depend on the general
+information like author, presentation title, etc.
 
 And that's it already!
 Have fun creating your own theme and maybe consider opening a pull request

--- a/examples/demo.typ
+++ b/examples/demo.typ
@@ -11,6 +11,8 @@
 
 #show link: set text(blue)
 
+#slide(theme-variant: "title slide")
+
 #new-section("Introduction")
 
 #slide(title: "About this presentation")[

--- a/examples/gauss.typ
+++ b/examples/gauss.typ
@@ -10,6 +10,8 @@
     date: "1784",
 )
 
+#slide(theme-variant: "title slide")
+
 #new-section("Introduction")
 
 #slide(title: "Problem statement")[

--- a/examples/simple.typ
+++ b/examples/simple.typ
@@ -9,6 +9,8 @@
     date: "March 2023",
 )
 
+#slide(theme-variant: "title slide")
+
 #new-section("My section name")
 
 #slide(title: "A boring static slide")[

--- a/slides.typ
+++ b/slides.typ
@@ -381,6 +381,5 @@
     let the-theme = theme(data)
     global-theme.update(the-theme)
 
-    // the-theme.title-slide
     body
 }

--- a/slides.typ
+++ b/slides.typ
@@ -180,13 +180,17 @@
     override-theme: none,
     ..args
 ) = {
-    pagebreak(weak: true)
+    locate( loc => {
+        if counter(page).at(loc).first() > 1 {
+            pagebreak(weak: true)
+        }
+    })
     logical-slide.step()
     locate( loc => {
         subslide.update(1)
         repetitions.update(1)
 
-        let slide-content = global-theme.at(loc).variants.at(theme-variant)
+        let slide-content = global-theme.at(loc).at(theme-variant)
         if override-theme != none {
             slide-content = override-theme
         }
@@ -212,7 +216,11 @@
 // ===============================
 
 #let slides-default-theme(color: teal) = data => {
-    let title-slide = {
+    let title-slide(slide-info, bodies) = {
+        if bodies.len() != 0 {
+            panic("title slide of default theme does not support any bodies")
+        }
+
         align(center + horizon)[
             #block(
                 stroke: ( y: 1mm + color ),
@@ -302,8 +310,9 @@
     }
 
     (
-        title-slide: title-slide,
-        variants: ( "default": default, "wake up": wake-up, ),
+        "title slide": title-slide,
+        "default": default,
+        "wake up": wake-up,
     )
 }
 
@@ -372,6 +381,6 @@
     let the-theme = theme(data)
     global-theme.update(the-theme)
 
-    the-theme.title-slide
+    // the-theme.title-slide
     body
 }

--- a/themes/bipartite.typ
+++ b/themes/bipartite.typ
@@ -6,7 +6,11 @@
   let my-bright = rgb("#fafafa")
   let my-accent = rgb("#fc9278")
 
-  let title-slide = {
+  let title-slide(slide-info, bodies) = {
+    if bodies.len() != 0 {
+        panic("title slide of bipartite theme does not support any bodies")
+    }
+
     block(
       width: 100%, height: 60%, outset: 0em, inset: 0em, breakable: false,
       stroke: none, spacing: 0em, fill: my-bright,
@@ -90,7 +94,9 @@
   }
 
   (
-    title-slide: title-slide,
-    variants: ( "default": west, "east": east, "center split": center-split ),
+    "title slide": title-slide,
+    "default": west,
+    "east": east,
+    "center split": center-split,
   )
 }


### PR DESCRIPTION
This changes the theme variant system in so far as the title slide must now be just a variant as any orher. Also users, must opt into heaving a title slide if they want one. They can now also decide to omit it.