### PR TITLE
Handout mode

### DIFF
--- a/book/src/config.md
+++ b/book/src/config.md
@@ -22,6 +22,8 @@ don't have to) provide the following arguments in the form of
 - `theme`: set a theme other than the default, see [this section](./themes.html)
 - `aspect-ratio`: either `"16-9"` (default) or `"4-3"` to specify if you want
   PDF pages with aspect ratio 16:9 or 4:3
+- `handout`: either `true` or `false` (default), set whether you want to produce
+  a handout version of these slides (see [this section](./dynamic.html#handout-mode))
 
 The data you provide in this configuration is propagated to the
 [theme](./themes.html) which then decides how to display all that.

--- a/book/src/dynamic.md
+++ b/book/src/dynamic.md
@@ -352,3 +352,32 @@ argument of the `#slide` function:
 ```
 
 Again, use this feature sparingly, as it decreases typesetting performance.
+
+## Handout mode
+If you to distribute your slides after your talk for further reference, you might
+not want to keep in all the dynamic content.
+Imagine using `one-by-one` on a bullet point list and readers having to scroll
+through endless pages when they just want to see the full list.
+
+You can use `handout: true` in your slides' configuration to achieve this:
+```typ
+#show: slides.with(
+  // ...
+  handout: true
+)
+```
+
+It has the effect that all dynamic visibility of elements _that reserve space_
+is switched off.
+So
+```typ
+Some text. #uncover("3-")[you cannot always see this] ...or can you?
+```
+behaves as
+```typ
+Some text. you cannot always see this ...or can you?
+```
+in handout mode, for example.
+
+Note that `only` and `alternatives` are **not** affected as there is no obvious
+way to unify their content to one slide.

--- a/examples/demo.typ
+++ b/examples/demo.typ
@@ -6,7 +6,7 @@
     title: [`typst-slides`: Easily creating slides in Typst ],
     subtitle: "An overview over all the features",
     short-title: "Slides template demo",
-    date: "April 2023"
+    date: "April 2023",
 )
 
 #show link: set text(blue)

--- a/slides.typ
+++ b/slides.typ
@@ -108,10 +108,13 @@
 
 #let _conditional-display(visible-subslides, reserve-space, mode, body) = {
     locate( loc => {
-        if reserve-space and not handout-mode.at(loc) {
-            repetitions.update(rep => calc.max(rep, _last-required-subslide(visible-subslides)))
+        let vs = if reserve-space and handout-mode.at(loc) {
+            (:)
+        } else {
+            visible-subslides
         }
-        if _check-visible(subslide.at(loc).first(), visible-subslides) {
+        repetitions.update(rep => calc.max(rep, _last-required-subslide(vs)))
+        if _check-visible(subslide.at(loc).first(), vs) {
             body
         } else if reserve-space {
             _slides-cover(mode, body)
@@ -128,14 +131,12 @@
 }
 
 #let one-by-one(start: 1, mode: "invisible", ..children) = {
-    repetitions.update(rep => calc.max(rep, start + children.pos().len() - 1))
     for (idx, child) in children.pos().enumerate() {
         uncover((beginning: start + idx), mode: mode, child)
     }
 }
 
 #let alternatives(start: 1, position: bottom + left, ..children) = {
-    repetitions.update(rep => calc.max(rep, start + children.pos().len() - 1))
     style(styles => {
         let sizes = children.pos().map(c => measure(c, styles))
         let max-width = calc.max(..sizes.map(sz => sz.width))

--- a/slides.typ
+++ b/slides.typ
@@ -7,6 +7,7 @@
 #let logical-slide = counter("logical-slide")
 #let repetitions = counter("repetitions")
 #let global-theme = state("global-theme", none)
+#let handout-mode = state("handout-mode", false)
 
 #let new-section(name) = section.update(name)
 
@@ -106,8 +107,10 @@
 }
 
 #let _conditional-display(visible-subslides, reserve-space, mode, body) = {
-    repetitions.update(rep => calc.max(rep, _last-required-subslide(visible-subslides)))
     locate( loc => {
+        if reserve-space and not handout-mode.at(loc) {
+            repetitions.update(rep => calc.max(rep, _last-required-subslide(visible-subslides)))
+        }
         if _check-visible(subslide.at(loc).first(), visible-subslides) {
             body
         } else if reserve-space {
@@ -329,6 +332,7 @@
     date: none,
     theme: slides-default-theme(),
     aspect-ratio: "16-9",
+    handout: false,
     body
 ) = {
 
@@ -353,6 +357,7 @@
     )
     let the-theme = theme(data)
     global-theme.update(the-theme)
+    handout-mode.update(handout)
 
     set text(size: 25pt)
 


### PR DESCRIPTION
This PR implements a handout mode.

It is always nice to harvest the fruits of earlier work. We can just rely on the fact that the dynamic display mechanism accepts intervals, especially empty ones. This means all that had to be done is to set the visible subslides for elements that reserve space (`uncover` etc.) to an empty interval (which means an empty dictionary, really) in handout mode.

`only` and `alternatives` behave identically in handout mode and in "normal" mode, as discussed in #22.

Users simply have to specify
```typ
#show: slides.with(
  // ...
  handout: true
)
```
now to profit from this new feature.

Closes #22. Pinging @rpitasky and @Holt59 as they participated in that issue.